### PR TITLE
feat: show delete button on [DELETED] comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "enzyme-adapter-react-16": "1.15.6",
     "i18next": "20.6.1",
     "lodash": "4.17.21",
-    "prism-react-renderer": "1.2.1",
     "prismjs": "1.25.0",
     "prop-types": "15.7.2",
     "qs": "6.10.1",

--- a/src/components/common/CodeReview.js
+++ b/src/components/common/CodeReview.js
@@ -270,8 +270,7 @@ class CodeReview extends Component {
       >
         <CommentEditor
           comment={comment}
-          // if a comment has the deleted flag it should not be editable
-          readOnly={this.getReadOnlyProperty(comment) || comment.data.deleted}
+          readOnly={this.getReadOnlyProperty(comment)}
           showReply={!isFeedbackView}
           focused={focusedId === comment._id}
           onReply={() => this.handleAddComment(comment.data.line, comment._id)}

--- a/src/components/common/CodeReview.js
+++ b/src/components/common/CodeReview.js
@@ -262,26 +262,44 @@ class CodeReview extends Component {
       return null;
     }
 
-    return childrenComments.map((comment) => (
-      <Paper
-        key={comment._id}
-        className={classes.commentContainer}
-        variant="outlined"
-      >
-        <CommentEditor
-          comment={comment}
-          readOnly={this.getReadOnlyProperty(comment)}
-          showReply={!isFeedbackView}
-          focused={focusedId === comment._id}
-          onReply={() => this.handleAddComment(comment.data.line, comment._id)}
-          onEditComment={(_id) => this.handleEdit(_id)}
-          onDeleteComment={(_id) => this.handleDelete(_id)}
-          onCancel={this.handleCancel}
-          onSubmit={(_id, content) => this.handleSubmit(_id, content)}
-        />
-        {this.renderChildrenComments(comments, comment._id)}
-      </Paper>
-    ));
+    return childrenComments.map((comment) => {
+      // verify if the comment has children by
+      // checking the length of the array of first order children
+      const hasChildrenComments =
+        comments.filter(
+          (childComment) => childComment.data.parent === comment._id,
+        ).length !== 0;
+
+      // set to true if:
+      // - the comment is not delete
+      // - the comment is deleted but it is the last comment in the tree -> so it can be deleted
+      const showDelete =
+        (comment.data.deleted && !hasChildrenComments) || !comment.data.deleted;
+
+      return (
+        <Paper
+          key={comment._id}
+          className={classes.commentContainer}
+          variant="outlined"
+        >
+          <CommentEditor
+            comment={comment}
+            readOnly={this.getReadOnlyProperty(comment)}
+            showReply={!isFeedbackView}
+            showDelete={showDelete}
+            focused={focusedId === comment._id}
+            onReply={() =>
+              this.handleAddComment(comment.data.line, comment._id)
+            }
+            onEditComment={(_id) => this.handleEdit(_id)}
+            onDeleteComment={(_id) => this.handleDelete(_id)}
+            onCancel={this.handleCancel}
+            onSubmit={(_id, content) => this.handleSubmit(_id, content)}
+          />
+          {this.renderChildrenComments(comments, comment._id)}
+        </Paper>
+      );
+    });
   }
 
   renderCodeReview(code, commentList) {

--- a/src/components/common/CommentEditor.js
+++ b/src/components/common/CommentEditor.js
@@ -77,6 +77,7 @@ class CommentEditor extends Component {
     focused: PropTypes.bool.isRequired,
     readOnly: PropTypes.bool,
     showReply: PropTypes.bool,
+    showDelete: PropTypes.bool,
     onEditComment: PropTypes.func.isRequired,
     onReply: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
@@ -116,6 +117,7 @@ class CommentEditor extends Component {
     botUsers: [],
     readOnly: false,
     showReply: true,
+    showDelete: true,
   };
 
   state = {
@@ -223,6 +225,7 @@ class CommentEditor extends Component {
       botUsers,
       onReply,
       showReply,
+      showDelete,
       lang,
     } = this.props;
     const { updatedAt = new Date().toISOString() } = comment;
@@ -261,13 +264,15 @@ class CommentEditor extends Component {
                     <EditIcon />
                   </IconButton>
                 ) : null}
-                <IconButton
-                  aria-label="delete"
-                  color="secondary"
-                  onClick={() => this.setState({ open: true })}
-                >
-                  <DeleteIcon />
-                </IconButton>
+                {showDelete ? (
+                  <IconButton
+                    aria-label="delete"
+                    color="secondary"
+                    onClick={() => this.setState({ open: true })}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                ) : null}
               </>
             ) : null}
             {showReply ? (

--- a/src/components/common/CommentEditor.js
+++ b/src/components/common/CommentEditor.js
@@ -252,13 +252,15 @@ class CommentEditor extends Component {
           <>
             {isHovered && !readOnly ? (
               <>
-                <IconButton
-                  aria-label="edit"
-                  color="primary"
-                  onClick={this.onEdit}
-                >
-                  <EditIcon />
-                </IconButton>
+                {!comment.data.deleted ? (
+                  <IconButton
+                    aria-label="edit"
+                    color="primary"
+                    onClick={this.onEdit}
+                  >
+                    <EditIcon />
+                  </IconButton>
+                ) : null}
                 <IconButton
                   aria-label="delete"
                   color="secondary"


### PR DESCRIPTION
A simpler solution was chosen, instead of going through the tree of comments to automate deletion, the possibility is left to the user to delete already deleted comments.

closes #22 