### PR TITLE
fix: reset interaction button

### DIFF
--- a/src/components/common/CodeReview.js
+++ b/src/components/common/CodeReview.js
@@ -225,10 +225,13 @@ class CodeReview extends Component {
   };
 
   handleDeleteThread = (commentId) => {
+    const { dispatchDeleteAppInstanceResource } = this.props;
     const thread = this.getCommentIdsInThread(commentId);
     // remove the line comment
     thread.pop();
-    thread.forEach((id) => this.handleDelete(id));
+    // this approach does not work because of the delay
+    // thread.forEach((id) => this.handleDelete(id));
+    thread.forEach((id) => dispatchDeleteAppInstanceResource(id));
   };
 
   handleCancel = () => {
@@ -499,20 +502,19 @@ class CodeReview extends Component {
     return thread;
   };
 
-  findParent = (comments, parentId) =>
-    comments.find((c) => c.data.parent === parentId);
+  findParent = (comments, parentId) => comments.find((c) => c._id === parentId);
 
   getCommentIdsInThread = (commentId) => {
     const { comments, botComments, teacherComments } = this.props;
     const allComments = [...comments, ...botComments, ...teacherComments];
-    const thread = [commentId];
+    const thread = [];
     let parentId = commentId;
     let parent = null;
     do {
       parent = this.findParent(allComments, parentId);
       if (parent) {
-        parentId = parent._id;
         thread.push(parentId);
+        parentId = parent.data.parent;
       }
     } while (parent);
 
@@ -561,7 +563,7 @@ class CodeReview extends Component {
             onCancel={this.handleCancel}
             onSubmit={(_id, content) => this.handleSubmit(_id, content)}
             onQuickResponse={this.handleQuickResponse}
-            onDeleteThread={this.handleDeleteThread}
+            onDeleteThread={(_id) => this.handleDeleteThread(_id)}
             adaptStyle={this.adaptHeight}
           />
         </Fragment>

--- a/src/components/modes/teacher/AvatarDialog.js
+++ b/src/components/modes/teacher/AvatarDialog.js
@@ -188,8 +188,8 @@ class AvatarDialog extends Component {
     } = this.props;
     const { avatar } = this.state;
 
-    // this is a new bot
-    if (avatarId === '') {
+    // this is a new bot so avatarId is null
+    if (!avatarId) {
       dispatchPostAppInstanceResource({
         data: avatar,
         type: BOT_USER,


### PR DESCRIPTION
This fixes some problems with the "reset interaction" button.

An alternative method for deleting the comments has been left as a comment. Currently this alternative approach (which is safer) fails without introducing a delay.

A change is open to discussion.