### PR TITLE
fix: ignore Graasp user not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "date-fns": "2.25.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
+    "http-status-codes": "2.2.0",
     "i18next": "20.6.1",
     "lodash": "4.17.21",
     "prismjs": "1.25.0",

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -54,7 +54,11 @@ const getUsers = async () => async (dispatch, getState) => {
         // fetch the user info
         const infoUrl = `${GRAASP_MAIN_DOMAIN + USERS_ENDPOINT}/${user.id}`;
         const userResponse = await fetch(infoUrl, JSON_GET_REQUEST);
-        await isErrorResponse(userResponse);
+        // did not manage to find the user
+        if (userResponse.status === 404) {
+          // return the user unchanged
+          return user;
+        }
         const graaspUserInfo = await userResponse.json();
         return {
           ...user,

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes';
 import { flag, getApiContext, isErrorResponse, postMessage } from './common';
 import {
   FLAG_GETTING_USERS,
@@ -55,7 +56,7 @@ const getUsers = async () => async (dispatch, getState) => {
         const infoUrl = `${GRAASP_MAIN_DOMAIN + USERS_ENDPOINT}/${user.id}`;
         const userResponse = await fetch(infoUrl, JSON_GET_REQUEST);
         // did not manage to find the user
-        if (userResponse.status === 404) {
+        if (userResponse.status === StatusCodes.NOT_FOUND) {
           // return the user unchanged
           return user;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6890,6 +6890,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+http-status-codes@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-2.2.0.tgz#bb2efe63d941dfc2be18e15f703da525169622be"
+  integrity sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==
+
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"


### PR DESCRIPTION
A really simple fix to ignore when request to get user with type `graasp` fails due to them not being registered yet.

closes #73