### PR TITLE
feat: add user list to bot settings

### DIFF
--- a/src/components/common/CodeReview.js
+++ b/src/components/common/CodeReview.js
@@ -25,6 +25,8 @@ import {
   ADAPT_HEIGHT_TIMEOUT,
   DEFAULT_ALLOW_COMMENTS_SETTING,
   DEFAULT_ALLOW_REPLIES_SETTING,
+  DEFAULT_BOT_USER_LIST_POLARITY_SETTING,
+  DEFAULT_BOT_USER_LIST_SETTING,
   DEFAULT_CODE_ID,
   DEFAULT_COMMENT_CONTENT,
   DEFAULT_COMMENT_HIDDEN_STATE,
@@ -602,9 +604,12 @@ class CodeReview extends Component {
       // check bot visibility setting
       if (comment.type === BOT_COMMENT) {
         const bot = botUsers.find((u) => u._id === comment.data.botId);
-        // should filter users from list
-        if (bot && bot.data.useUserList) {
-          const { userListPolarity, userList } = bot.data;
+        // check that the bot is found and that it wants to restrict access
+        if (bot && bot.data?.useUserList) {
+          const {
+            userListPolarity = DEFAULT_BOT_USER_LIST_POLARITY_SETTING,
+            userList = DEFAULT_BOT_USER_LIST_SETTING,
+          } = bot.data;
           // when polarity is HIDE_BOT, users in the list should not see the bot
           // when polarity is SHOW_BOT, users outside the list should not see the bot
           if (
@@ -706,16 +711,17 @@ class CodeReview extends Component {
         numThreads && !hiddenCommentState ? (
           <tr className="comment">
             <td className="comment editor" colSpan={2}>
-              {parentComments.map((comment) =>
-                this.shouldShowComment(comment) ? (
-                  <Paper
-                    key={comment._id}
-                    className={classes.commentContainer}
-                    variant="outlined"
-                  >
-                    {this.renderCommentThread(comment, lineComments)}
-                  </Paper>
-                ) : null,
+              {parentComments.map(
+                (comment) =>
+                  this.shouldShowComment(comment) && (
+                    <Paper
+                      key={comment._id}
+                      className={classes.commentContainer}
+                      variant="outlined"
+                    >
+                      {this.renderCommentThread(comment, lineComments)}
+                    </Paper>
+                  ),
               )}
             </td>
           </tr>

--- a/src/components/modes/teacher/AvatarDialog.js
+++ b/src/components/modes/teacher/AvatarDialog.js
@@ -10,6 +10,16 @@ import {
   FormLabel,
   Switch,
   FormControlLabel,
+  Tabs,
+  Tab,
+  List,
+  ListItem,
+  Checkbox,
+  ListItemText,
+  ListItemIcon,
+  Paper,
+  RadioGroup,
+  Radio,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
@@ -21,10 +31,17 @@ import {
   closeAvatarDialog,
   postAppInstanceResource,
   patchAppInstanceResource,
+  getUsers,
 } from '../../../actions';
 import Loader from '../../common/Loader';
 import { BOT_USER } from '../../../config/appInstanceResourceTypes';
-import { JSON_LANG, PUBLIC_VISIBILITY } from '../../../config/settings';
+import {
+  DEFAULT_BOT_USER_LIST_POLARITY_SETTING,
+  HIDE_BOT,
+  JSON_LANG,
+  PUBLIC_VISIBILITY,
+  SHOW_BOT,
+} from '../../../config/settings';
 import {
   DEFAULT_PERSONALITY_JSON,
   DEFAULT_VALIDATOR_MESSAGE,
@@ -40,9 +57,22 @@ const DEFAULT_AVATAR = {
   uri: '',
   autoBot: false,
   autoSeed: false,
+  useUserList: false,
+  userListPolarity: DEFAULT_BOT_USER_LIST_POLARITY_SETTING,
+  userList: [],
   personality: stringifyPersonality(DEFAULT_PERSONALITY_JSON),
   description: '',
 };
+
+const BOT_IDENTITY_SETTINGS_TAB = 'BOT_IDENTITY_SETTINGS_TAB';
+const AUTO_BOT_SETTINGS_TAB = 'AUTO_BOT_SETTINGS_TAB';
+const MORE_SETTINGS_TAB = 'MORE_SETTINGS_TAB';
+const DEFAULT_TAB = BOT_IDENTITY_SETTINGS_TAB;
+const TABS = [
+  BOT_IDENTITY_SETTINGS_TAB,
+  AUTO_BOT_SETTINGS_TAB,
+  MORE_SETTINGS_TAB,
+];
 
 function getModalStyle() {
   const top = 50;
@@ -94,8 +124,16 @@ const styles = (theme) => ({
   modal: {
     overflowY: 'scroll',
   },
+  container: {
+    display: 'block',
+    marginTop: theme.spacing(2),
+  },
   noFlex: {
     display: 'block',
+  },
+  userListContainer: {
+    maxHeight: '40vh',
+    overflow: 'auto',
   },
   lastGrid: {
     margin: '0px',
@@ -127,6 +165,8 @@ class AvatarDialog extends Component {
       button: PropTypes.string,
       editor: PropTypes.string,
       paper: PropTypes.string,
+      userListContainer: PropTypes.string,
+      container: PropTypes.string,
       noFlex: PropTypes.string,
       modal: PropTypes.string,
       lastGrid: PropTypes.string,
@@ -140,6 +180,11 @@ class AvatarDialog extends Component {
       uri: PropTypes.string,
       autoBot: PropTypes.bool,
       autoSeed: PropTypes.bool,
+      useUserList: PropTypes.bool,
+      userListPolarity: PropTypes.string,
+      userList: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      ),
       personality: PropTypes.string,
       description: PropTypes.string,
     }),
@@ -147,10 +192,18 @@ class AvatarDialog extends Component {
     dispatchCloseAvatarDialog: PropTypes.func.isRequired,
     dispatchPostAppInstanceResource: PropTypes.func.isRequired,
     dispatchPatchAppInstanceResource: PropTypes.func.isRequired,
+    dispatchGetUsers: PropTypes.func.isRequired,
+    users: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      }),
+    ),
   };
 
   static defaultProps = {
     avatar: DEFAULT_AVATAR,
+    users: [],
   };
 
   state = (() => {
@@ -162,8 +215,14 @@ class AvatarDialog extends Component {
         severity: VALIDATOR_SUCCESS,
         message: DEFAULT_VALIDATOR_MESSAGE,
       },
+      tabIndex: TABS.indexOf(DEFAULT_TAB),
     };
   })();
+
+  componentDidMount() {
+    const { dispatchGetUsers } = this.props;
+    dispatchGetUsers();
+  }
 
   componentDidUpdate(prevProps, prevState) {
     const { avatar: prevPropsAvatar } = prevProps;
@@ -241,6 +300,13 @@ class AvatarDialog extends Component {
     this.handlePersonalityVerification();
   };
 
+  handleChangeBotVisibility = (value) => {
+    console.log(value);
+    this.setState((prevState) => ({
+      avatar: { ...prevState.avatar, userListPolarity: value },
+    }));
+  };
+
   handleAddEmptyStep = () => {
     this.setState((prevState) => {
       const newPersonality = stringifyPersonality(
@@ -307,9 +373,44 @@ class AvatarDialog extends Component {
     dispatchCloseAvatarDialog();
   };
 
+  handleOnClickUserChecked = (value) => {
+    const { avatar } = this.state;
+    const { userList } = avatar;
+    const currentIndex = userList.indexOf(value);
+    // make a copy of the array
+    const newUserList = [...userList];
+
+    // not found
+    if (currentIndex === -1) {
+      newUserList.push(value);
+    } else {
+      newUserList.splice(currentIndex, 1);
+    }
+    this.setState((prevState) => ({
+      avatar: { ...prevState.avatar, userList: newUserList },
+    }));
+  };
+
+  handleOnClickAllUsers = (check) => {
+    const { users } = this.props;
+    if (check) {
+      this.setState((prevState) => ({
+        avatar: { ...prevState.avatar, userList: users.map((u) => u.id) },
+      }));
+    } else {
+      this.setState((prevState) => ({
+        avatar: { ...prevState.avatar, userList: [] },
+      }));
+    }
+  };
+
+  handleChangeTab = (event, newValue) => {
+    this.setState({ tabIndex: newValue });
+  };
+
   renderModalContent() {
-    const { t, activity, classes, avatar: avatarProp } = this.props;
-    const { avatar, validator } = this.state;
+    const { t, activity, classes, avatar: avatarProp, users } = this.props;
+    const { avatar, validator, tabIndex } = this.state;
 
     const hasChanged = !_.isEqual(avatarProp, avatar);
 
@@ -379,6 +480,36 @@ class AvatarDialog extends Component {
       />
     );
 
+    const userListSwitchControl = (
+      <Switch
+        color="primary"
+        value="useUserList"
+        size="small"
+        checked={avatar.useUserList}
+        onChange={this.handleChangeSwitch('useUserList')}
+      />
+    );
+
+    const checkAllButton = (
+      <Button
+        color="primary"
+        variant="outlined"
+        onClick={() => this.handleOnClickAllUsers(true)}
+      >
+        {t('Check all')}
+      </Button>
+    );
+
+    const unCheckAllButton = (
+      <Button
+        color="primary"
+        variant="outlined"
+        onClick={() => this.handleOnClickAllUsers(false)}
+      >
+        {t('Uncheck all')}
+      </Button>
+    );
+
     const addEmptyStepButton = (
       <Button
         color="primary"
@@ -416,80 +547,176 @@ class AvatarDialog extends Component {
 
     return (
       <>
-        <Grid
-          container
-          direction="column"
-          spacing={3}
-          alignItems="stretch"
-          className={classes.noFlex}
-        >
-          <Grid item className={classes.noFlex}>
-            {nameControl}
-          </Grid>
-          <Grid item className={classes.noFlex}>
-            {uriControl}
-          </Grid>
-          <Grid item className={classes.noFlex}>
-            {descriptionControl}
-          </Grid>
+        <div hidden={tabIndex !== TABS.indexOf(BOT_IDENTITY_SETTINGS_TAB)}>
           <Grid
             container
-            direction="row"
+            direction="column"
             spacing={3}
-            justifyContent="space-between"
-            alignItems="center"
-            className={classes.lastGrid}
+            alignItems="stretch"
+            className={classes.container}
+          >
+            <Grid item className={classes.noFlex}>
+              {nameControl}
+            </Grid>
+            <Grid item className={classes.noFlex}>
+              {uriControl}
+            </Grid>
+            <Grid item className={classes.noFlex}>
+              {descriptionControl}
+            </Grid>
+          </Grid>
+        </div>
+        <div hidden={tabIndex !== TABS.indexOf(AUTO_BOT_SETTINGS_TAB)}>
+          <Grid
+            container
+            direction="column"
+            spacing={3}
+            alignItems="stretch"
+            className={classes.container}
+          >
+            <Grid
+              container
+              direction="row"
+              spacing={3}
+              justifyContent="space-between"
+              alignItems="center"
+              className={classes.lastGrid}
+            >
+              <Grid item>
+                <FormControlLabel
+                  control={autoBotSwitchControl}
+                  label={t('Enable Auto Reply')}
+                />
+              </Grid>
+              {avatar.autoBot ? (
+                <Grid item>
+                  <FormControlLabel
+                    control={autoSeedSwitchControl}
+                    label={t('Enable Automatic Message Seeding')}
+                  />
+                </Grid>
+              ) : null}
+            </Grid>
+            {avatar.autoBot ? (
+              <>
+                <Grid container direction="row" justifyContent="space-evenly">
+                  <Grid item>{addEmptyStepButton}</Grid>
+                  <Grid item>{resetToDefaultButton}</Grid>
+                  <Grid item>{fileUploadControl}</Grid>
+                </Grid>
+                <Grid item>
+                  <FormLabel>{t('Bot Personality')}</FormLabel>
+                  <Editor
+                    className={classes.editor}
+                    height="20vh"
+                    defaultLanguage={JSON_LANG}
+                    value={avatar.personality}
+                    onChange={this.handleChangeEditor('personality')}
+                    options={{
+                      scrollBeyondLastLine: false,
+                      detectIndentation: false,
+                      tabSize: 2,
+                    }}
+                  />
+                  <Alert
+                    variant={
+                      validator.severity === VALIDATOR_ERROR
+                        ? 'filled'
+                        : 'outlined'
+                    }
+                    severity={validator.severity}
+                  >
+                    {t(validator.message)}
+                  </Alert>
+                </Grid>
+              </>
+            ) : null}
+          </Grid>
+        </div>
+        <div hidden={tabIndex !== TABS.indexOf(MORE_SETTINGS_TAB)}>
+          <Grid
+            container
+            direction="column"
+            spacing={3}
+            alignItems="stretch"
+            className={classes.container}
           >
             <Grid item>
               <FormControlLabel
-                control={autoBotSwitchControl}
-                label={t('Enable Auto Reply')}
+                control={userListSwitchControl}
+                label={t('Enable selective audience')}
               />
             </Grid>
-            {avatar.autoBot ? (
-              <Grid item>
-                <FormControlLabel
-                  control={autoSeedSwitchControl}
-                  label={t('Enable Automatic Message Seeding')}
-                />
-              </Grid>
+            {avatar.useUserList ? (
+              <>
+                <Grid
+                  container
+                  item
+                  direction="row"
+                  justifyContent="space-evenly"
+                >
+                  <Grid item>{checkAllButton}</Grid>
+                  <Grid item>{unCheckAllButton}</Grid>
+                  {/* <Grid item>{fileUploadControl}</Grid> */}
+                </Grid>
+                <Grid item>
+                  <FormLabel component="legend">
+                    {t('For the selected users, bot will be')}{' '}
+                  </FormLabel>
+                  <RadioGroup
+                    aria-label="show-bot"
+                    name="userListPolarity"
+                    value={
+                      avatar.userListPolarity ||
+                      DEFAULT_BOT_USER_LIST_POLARITY_SETTING
+                    }
+                    onChange={(e) =>
+                      this.handleChangeBotVisibility(e.target.value)
+                    }
+                  >
+                    <FormControlLabel
+                      value={SHOW_BOT}
+                      control={<Radio color="primary" />}
+                      label={t(SHOW_BOT)}
+                    />
+                    <FormControlLabel
+                      value={HIDE_BOT}
+                      control={<Radio color="primary" />}
+                      label={t(HIDE_BOT)}
+                    />
+                  </RadioGroup>
+                </Grid>
+                <Grid item>
+                  <Paper
+                    elevation={0}
+                    variant="outlined"
+                    className={classes.userListContainer}
+                  >
+                    <List>
+                      {users.map((u) => (
+                        <ListItem
+                          key={u.id}
+                          dense
+                          button
+                          onClick={() => this.handleOnClickUserChecked(u.id)}
+                        >
+                          <ListItemIcon>
+                            <Checkbox
+                              color="primary"
+                              // if the index is different from -1 means the user is included in the list
+                              checked={avatar.userList.indexOf(u.id) !== -1}
+                            />
+                          </ListItemIcon>
+                          <ListItemText primary={u.name} secondary={u.id} />
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Paper>
+                </Grid>
+              </>
             ) : null}
           </Grid>
-          {avatar.autoBot ? (
-            <>
-              <Grid container direction="row" justifyContent="space-evenly">
-                <Grid item>{addEmptyStepButton}</Grid>
-                <Grid item>{resetToDefaultButton}</Grid>
-                <Grid item>{fileUploadControl}</Grid>
-              </Grid>
-              <Grid item>
-                <FormLabel>{t('Bot Personality')}</FormLabel>
-                <Editor
-                  className={classes.editor}
-                  height="20vh"
-                  defaultLanguage={JSON_LANG}
-                  value={avatar.personality}
-                  onChange={this.handleChangeEditor('personality')}
-                  options={{
-                    scrollBeyondLastLine: false,
-                    detectIndentation: false,
-                    tabSize: 2,
-                  }}
-                />
-                <Alert
-                  variant={
-                    validator.severity === VALIDATOR_ERROR
-                      ? 'filled'
-                      : 'outlined'
-                  }
-                  severity={validator.severity}
-                >
-                  {t(validator.message)}
-                </Alert>
-              </Grid>
-            </>
-          ) : null}
-        </Grid>
+        </div>
         <Divider className={classes.divider} />
         <Button
           variant="contained"
@@ -514,6 +741,7 @@ class AvatarDialog extends Component {
 
   render() {
     const { open, classes, t } = this.props;
+    const { tabIndex } = this.state;
     return (
       <div>
         <Modal
@@ -531,6 +759,20 @@ class AvatarDialog extends Component {
             >
               {t('Settings')}
             </Typography>
+            <Tabs
+              centered
+              value={tabIndex}
+              onChange={(e, v) => this.handleChangeTab(e, v)}
+              indicatorColor="primary"
+              textColor="primary"
+            >
+              <Tab
+                label={t('Bot Identity Settings')}
+                id={BOT_IDENTITY_SETTINGS_TAB}
+              />
+              <Tab label={t('Auto Bot Settings')} id={AUTO_BOT_SETTINGS_TAB} />
+              <Tab label={t('More Settings')} id={MORE_SETTINGS_TAB} />
+            </Tabs>
             {this.renderModalContent()}
           </div>
         </Modal>
@@ -539,7 +781,12 @@ class AvatarDialog extends Component {
   }
 }
 
-const mapStateToProps = ({ layout, appInstance, appInstanceResources }) => {
+const mapStateToProps = ({
+  layout,
+  appInstance,
+  appInstanceResources,
+  users,
+}) => {
   const { avatarId } = layout.avatarDialog;
   return {
     open: layout.avatarDialog.open,
@@ -548,6 +795,7 @@ const mapStateToProps = ({ layout, appInstance, appInstanceResources }) => {
     avatar: appInstanceResources.content.find(
       (r) => r.type === BOT_USER && r._id === avatarId,
     )?.data,
+    users: users.content,
   };
 };
 
@@ -555,6 +803,7 @@ const mapDispatchToProps = {
   dispatchPatchAppInstanceResource: patchAppInstanceResource,
   dispatchPostAppInstanceResource: postAppInstanceResource,
   dispatchCloseAvatarDialog: closeAvatarDialog,
+  dispatchGetUsers: getUsers,
 };
 
 const ConnectedComponent = connect(

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -44,6 +44,10 @@ export const DEFAULT_ALLOW_REPLIES_SETTING = true;
 export const DEFAULT_ALLOW_COMMENTS_SETTING = true;
 export const DEFAULT_CODE_CONTENT_SETTING = '';
 
+export const SHOW_BOT = 'visible';
+export const HIDE_BOT = 'hidden';
+export const DEFAULT_BOT_USER_LIST_POLARITY_SETTING = SHOW_BOT;
+
 // time to wait in ms
 export const ADAPT_HEIGHT_TIMEOUT = 50;
 

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -46,7 +46,7 @@ export const DEFAULT_CODE_CONTENT_SETTING = '';
 
 export const SHOW_BOT = 'visible';
 export const HIDE_BOT = 'hidden';
-export const DEFAULT_BOT_USER_LIST_POLARITY_SETTING = SHOW_BOT;
+export const DEFAULT_BOT_USER_LIST_POLARITY_SETTING = HIDE_BOT;
 
 // time to wait in ms
 export const ADAPT_HEIGHT_TIMEOUT = 50;

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -47,6 +47,8 @@ export const DEFAULT_CODE_CONTENT_SETTING = '';
 export const SHOW_BOT = 'visible';
 export const HIDE_BOT = 'hidden';
 export const DEFAULT_BOT_USER_LIST_POLARITY_SETTING = HIDE_BOT;
+export const DEFAULT_BOT_USER_LIST_SETTING = [];
+export const DEFAULT_BOT_USE_USER_LIST_SETTING = false;
 
 // time to wait in ms
 export const ADAPT_HEIGHT_TIMEOUT = 50;


### PR DESCRIPTION
This PR adds the ability to create a list of users that will see/not see a bot's comments.
The list can be set to "see by default" or "hide by default" so that new users will get the desired visibility without needing to update the list.

![Screenshot 2022-03-14 at 17 40 56](https://user-images.githubusercontent.com/39373170/158219519-937a6b8e-0915-487a-a73d-57601bfa9322.png)

closes #76 