### PR TITLE
fix: adapt visibility icons to real number of comments shown

### DIFF
--- a/src/components/common/CodeReviewTools.js
+++ b/src/components/common/CodeReviewTools.js
@@ -116,9 +116,7 @@ class CodeReviewTools extends React.Component {
   static propTypes = {
     classes: PropTypes.shape({
       container: PropTypes.string.isRequired,
-      gridRow: PropTypes.string.isRequired,
       toolbar: PropTypes.string.isRequired,
-      lastGrid: PropTypes.string.isRequired,
       selectUsers: PropTypes.string.isRequired,
       selectVersions: PropTypes.string.isRequired,
       toggleButton: PropTypes.string.isRequired,
@@ -134,8 +132,8 @@ class CodeReviewTools extends React.Component {
     showHistoryDropdown: PropTypes.bool,
     hideCommentsCallback: PropTypes.func.isRequired,
     codeEditorSettings: PropTypes.shape({
-      codeId: PropTypes.string.isRequired,
-      code: PropTypes.string.isRequired,
+      codeId: PropTypes.string,
+      code: PropTypes.string,
     }).isRequired,
     topBarVisible: PropTypes.bool.isRequired,
     allVisibleState: PropTypes.bool.isRequired,

--- a/src/components/common/CommentView.js
+++ b/src/components/common/CommentView.js
@@ -218,7 +218,7 @@ class CommentView extends Component {
         name: PropTypes.string,
         initials: PropTypes.string,
         allowHumanIntervention: PropTypes.bool,
-        data: { personality: PropTypes.string },
+        data: PropTypes.shape({ personality: PropTypes.string }),
       }),
     ),
     // activity: PropTypes.number,
@@ -907,7 +907,7 @@ class CommentView extends Component {
     }
 
     return (
-      <div ref={this.commentRef}>
+      <div ref={this.commentRef} key={comment._id}>
         <Card
           className={classes.root}
           elevation={0}

--- a/src/components/common/CommitInfoDialog.js
+++ b/src/components/common/CommitInfoDialog.js
@@ -77,7 +77,7 @@ export class CommitInfoDialog extends Component {
         alignItems="stretch"
       >
         {commit.map(({ label, value }) => (
-          <Grid item container spacing={1}>
+          <Grid item container spacing={1} key={label}>
             <Grid item xs={12} sm={4}>
               <FormLabel>{t(label)}</FormLabel>
             </Grid>


### PR DESCRIPTION
This PR fixes visibility icons showing when bot comments are not shown to selected students.

closes #85 