### PR TITLE
fix: correct avatar bug and add upload list of users feature

### DIFF
--- a/src/components/modes/teacher/AvatarDialog.js
+++ b/src/components/modes/teacher/AvatarDialog.js
@@ -45,6 +45,7 @@ import {
   JSON_LANG,
   PUBLIC_VISIBILITY,
   SHOW_BOT,
+  SNACKBAR_AUTO_HIDE_DURATION,
 } from '../../../config/settings';
 import {
   DEFAULT_PERSONALITY_JSON,
@@ -476,12 +477,17 @@ class AvatarDialog extends Component {
     }
 
     const sortedUsers = users.sort((a, b) => {
+      // sort users by name
       if (userSortByName) {
+        // use localCompare to determine lexicographical order of strings (a->z)
         return a.name.localeCompare(b.name);
       }
+      // sort users by id when ids are strings
       if (typeof a.id === 'string') {
+        // use localCompare to determine lexicographical order of strings (a->z)
         return a.id.localeCompare(b.id);
       }
+      // by default assume ids are numbers, and order them by ascending order
       return a.id - b.id;
     });
 
@@ -857,7 +863,7 @@ class AvatarDialog extends Component {
         </Button>
         <Snackbar
           open={snackOpen}
-          autoHideDuration={6000}
+          autoHideDuration={SNACKBAR_AUTO_HIDE_DURATION}
           onClose={this.handleCloseSnackAlert}
         >
           <Alert onClose={this.handleCloseSnackAlert} severity="error">

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -49,6 +49,7 @@ export const DEFAULT_PENDING_FLAGS_ONLY_SETTING = true;
 export const SHOW_BOT = 'visible';
 export const HIDE_BOT = 'hidden';
 export const DEFAULT_BOT_USER_LIST_POLARITY_SETTING = HIDE_BOT;
+export const DEFAULT_BOT_USER_LIST_SORT_BY_NAME_SETTING = true;
 export const DEFAULT_BOT_USER_LIST_SETTING = [];
 export const DEFAULT_BOT_USE_USER_LIST_SETTING = false;
 

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -56,6 +56,9 @@ export const DEFAULT_BOT_USE_USER_LIST_SETTING = false;
 // time to wait in ms
 export const ADAPT_HEIGHT_TIMEOUT = 50;
 
+// snackbar auto hide duration in ms
+export const SNACKBAR_AUTO_HIDE_DURATION = 6000;
+
 // special id for newly created comments
 export const NEW_COMMENT_ID = '';
 


### PR DESCRIPTION
This PR corrects the bug in avatar settings and adds the possibility of importing ids list to be set as the bot's `userList`.
Also the list can now be sorted by `name` or by `userId`.
New UI for the settings:
<img width="744" alt="Screenshot 2022-04-27 at 14 58 50" src="https://user-images.githubusercontent.com/39373170/165523457-8b504ddf-ce0e-4d50-92ae-a904709d3d8b.png">

A Toast appears if the file can not be processed correctly:
<img width="868" alt="Screenshot 2022-04-27 at 14 59 04" src="https://user-images.githubusercontent.com/39373170/165523576-1c7ee5b1-ad70-4e0c-b434-ab3c00a8a547.png">

closes #90 